### PR TITLE
Add new options to make it easier to run in a multi-app repo and with CI tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Command line script used to analyze git commits/tags, parse out Jira ticket IDs,
 | --app | Optional app name, this is used as a helper to set the `--release-name` and `--previous-tag`. |
 | --repo-path | Path to git repository |
 | --release-name | Optional release name to use, if not provided the `--release-tag` is used, or if `--app` is present a computed <app>-<date> is used. |
+| --description | Optional description field used for the fix version description. |
 | --release-tag | Most recent tag, start bound for commits included in release. |
 | --previous-tag | Oldest tag, end bound for commits included in release. |
 | --jira-base-url | Root of your jira URL, like such as `https://traackr.atlassian.net` |

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Command line script used to analyze git commits/tags, parse out Jira ticket IDs,
 
 | command | description |
 | ------- | ----------- |
-| --release-name | Optional release name, if omitted the `--release-tag` option is used. | 
+| --app | Optional app name, this is used as a helper to set the `--release-name` and `--previous-tag`. |
 | --repo-path | Path to git repository |
+| --release-name | Optional release name to use, if not provided the `--release-tag` is used, or if `--app` is present a computed <app>-<date> is used. |
 | --release-tag | Most recent tag, start bound for commits included in release. |
 | --previous-tag | Oldest tag, end bound for commits included in release. |
 | --jira-base-url | Root of your jira URL, like such as `https://traackr.atlassian.net` |
@@ -26,11 +27,31 @@ Command line script used to analyze git commits/tags, parse out Jira ticket IDs,
 | --commit-pattern | Regular expression using python syntax for parsing commit messages. Use `key` and `value` named groups for the Jira ticket id `key` pattern and commit message `value`. |
 | --assume-yes | If provided any prompts will be defaulted to `yes`. Default value is `False`. |
 | --allow-multiple-versions | Allow multiple fix versions on a single ticket. For some projects it may be desirable to have multiple fix versions attached to a single ticket. For instance a library and consumer are both modified for one feature. Default value is `False`. |
+| --create-tag | This flag indicates whether or not to tag the repository with the `--release-name` after finishing.
 | --dry-run | Prevents Jira modifications. Default value is `True`. |
 
 #### example command
+
+## Release an app
+This style command is for integrating with a CI tool. All commits from the most recent until the next tag matching `skynet-*` will be considered. Those which match the commit-pattern will be validated in Jira and tagged with a fix version.
 ```
 ./release_fix_versioner.py
+       --dry-run false
+       --app skynet
+       --create-tag
+       --repo-path ~/skynet/
+       --jira-base-url cyberdyne-systems.atlassian.net
+       --jira-username cyberdyne
+       --jira-password cyberdyne1997
+       --jira-project SNAI
+       --commit-pattern "(?P<key>[\w]*-[\d]*)[ :-](?P<value>.*)"
+```
+
+## Release between two tags.
+This is typically done as a post-release step when releases involve a tag. In this example all commits between `rev-1.49` and `rev-1.50` are considered. Those which match the commit-pattern will be validated in Jira and tagged with a fix version.
+```
+./release_fix_versioner.py
+       --dry-run false
        --release-name "1.50 - Stemming sentience"
        --repo-path ~/skynet/
        --release-tag rev-1.50

--- a/release_fix_versioner.py
+++ b/release_fix_versioner.py
@@ -15,6 +15,7 @@ def parse_args():
     parser.add_argument('--app', required=False, help='Automates setting "--release-tag <app>-<timestamp>" and "--previous-tag <app>-*". ')
     parser.add_argument('--repo-path', required=True, help='Path to the repo being released.')
     parser.add_argument('--release-name', help='Release name to use in Jira, if not provided the --release-tag is used, or if --app is present a computed <app>-<date> is used.')
+    parser.add_argument('--release-description', required=False, help='Optional description field used for the fix version.')
     parser.add_argument('--release-tag', required=False, help='Most recent tag for this release, if wildcards are included will use the most recent match. If not present the most recent commit will be used.')
     parser.add_argument('--previous-tag', required=False, help='Tag for the last release, if wildcards are included will use the most recent match. It is required if --app is not specified.')
     parser.add_argument('--jira-base-url', required=True, help='Root of your jira URL, like \'https://traackr.atlassian.net\'')
@@ -140,7 +141,7 @@ def validate_jira_id(jira_id, allow_multiple_fix_versions, base_url, jira_userna
         raise ValueError(message)
 
 
-def create_fix_version(fix_version_name, jira_project, base_url, jira_username, jira_password):
+def create_fix_version(fix_version_name, description, jira_project, base_url, jira_username, jira_password):
     """ Create a fix version in given project with given name, returns the fix version id or raises an exception. """
     post_data = {
         'name': fix_version_name,
@@ -148,6 +149,9 @@ def create_fix_version(fix_version_name, jira_project, base_url, jira_username, 
         'released': True,
         'userReleaseDate': datetime.now().strftime('%d/%B/%Y')
     }
+
+    if description:
+        post_data['description'] = description
 
     response = requests.post(
         base_url + '/rest/api/2/version',
@@ -274,7 +278,7 @@ def main():
         sys.exit(-1)
 
     # Create fix version.
-    fix_version_id = create_fix_version(release_name, args.jira_project, args.jira_base_url, args.jira_username, args.jira_password)
+    fix_version_id = create_fix_version(release_name, args.description, args.jira_project, args.jira_base_url, args.jira_username, args.jira_password)
 
     # Apply fix version to tickets.
     for item in valid_tickets.items():


### PR DESCRIPTION
The main idea is that any app which can be released in your repository will have an associated key. Then on your CI server you can have a command which will automatically:
1) lookup the last tag for that key, for instance `myApp-2018-01-20T13:12:11Z`
2) get all tickets that have been referenced in commits since that tag was made
3) validate those tickets exist and are closed
4) create a Jira fix version like `myApp-NOW`
5) tag each of those Jira tickets
6) create and push new tag like `myApp-NOW`

With this process you can leave a static command at the end of your deployment process and it should dynamically manage itself, fix versions and git tags.